### PR TITLE
demo: Trigger all 10 DevSecOps workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,14 +280,34 @@ All code passes security scanning with zero findings:
 
 ### DevSecOps CI/CD Workflows
 
-Automated security scanning runs on every PR via GitHub Actions:
+11 automated workflows powered by GitHub Actions + Kiro CLI headless mode:
+
+#### PR Gate (always triggered)
+
+| Workflow | What It Does |
+|----------|--------------|
+| **Kiro Code Review** | AI-powered code review with security + quality analysis |
+| **Kiro Compliance Gate** | MAS TRM / SOC2 regulatory compliance check |
+| **Kiro Secret Scanning** | Credential and secret leak detection |
+| **PII & Secrets Scan** | detect-secrets + PII patterns (emails, AWS account IDs, SSNs) |
+
+#### PR Gate (path-filtered)
 
 | Workflow | Trigger | What It Does |
 |----------|---------|--------------|
-| **PII & Secrets Scan** | All PRs | Detects hardcoded secrets (detect-secrets) and PII patterns (emails, AWS account IDs, SSNs) |
-| **Python Security & Lint** | PRs touching `*.py` | Bandit SAST scan (medium+ blocks merge), pip-audit for vulnerable dependencies, Ruff + Black linting |
-| **IaC Security Scan** | PRs touching `infra/` | Checkov scans CDK/CloudFormation for misconfigurations |
-| **SBOM & License** | PRs touching `pyproject.toml` | Generates CycloneDX SBOM, blocks restrictive licenses (GPL/AGPL/SSPL) |
+| **Python Security & Lint** | `*.py`, `pyproject.toml` | Bandit SAST (medium+ blocks merge), pip-audit, Ruff + Black |
+| **Kiro Test Generation** | `*.py`, `*.ts` | Auto-suggest test cases for new code |
+| **IaC Security Scan** | `infra/` | Checkov scans CDK/CloudFormation for misconfigurations |
+| **Kiro IaC Security** | `cdk/`, `*.tf`, `cloudformation/` | IaC security scan for Terraform, CFN, CDK |
+| **Kiro Dependency Risk** | `pyproject.toml`, `requirements.txt` | CVE, license, supply chain risk assessment |
+| **SBOM & License** | `pyproject.toml` | CycloneDX SBOM, blocks restrictive licenses (GPL/AGPL/SSPL) |
+
+#### Release & Scheduled
+
+| Workflow | Trigger | What It Does |
+|----------|---------|--------------|
+| **Kiro Release Notes** | Tag/release | Auto-generate changelog |
+| **Kiro Tech Debt** | Weekly (Mon 9AM UTC) | Tech debt analysis and tracking |
 
 All workflows enforce **least-privilege** (`permissions: contents: read`), **pinned tool versions**, and **pip caching** for fast CI.
 

--- a/infra/cdk/shared_stack.py
+++ b/infra/cdk/shared_stack.py
@@ -1,3 +1,4 @@
+# DevSecOps: IaC security scanning enabled via checkov + kiro-iac-security
 """Shared infrastructure stack: VPC, WAF, KMS keys, CloudWatch log groups.
 
 Follows AWS Well-Architected Framework:

--- a/packages/shared/demo_security.py
+++ b/packages/shared/demo_security.py
@@ -1,0 +1,14 @@
+"""Demo: DevSecOps workflow trigger test.
+
+This file demonstrates that all security scanning workflows
+are triggered correctly on PR creation.
+"""
+
+
+def validate_input(user_input: str) -> str:
+    """Sanitize user input - demonstrates secure coding pattern."""
+    if not isinstance(user_input, str):
+        raise TypeError("Input must be a string")
+    # Strip potential injection characters
+    sanitized = user_input.replace("<", "&lt;").replace(">", "&gt;")
+    return sanitized.strip()[:1000]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-ai-industry-use-cases"
-version = "2.0.0"
+version = "2.1.0"
 description = "Enterprise Agentic AI applications across 6 industries, built with AWS Strands + Bedrock AgentCore"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Demo PR — DevSecOps Workflow Trigger Test

This PR contains minimal changes designed to trigger **all 10 PR-gate workflows**:

### Always triggered (all PRs):
1. ✅ kiro-code-review
2. ✅ kiro-compliance-gate
3. ✅ kiro-secret-scanning
4. ✅ pii-secrets-scan

### Triggered by `*.py` change:
5. ✅ python-security-lint
6. ✅ kiro-test-generation

### Triggered by `infra/` + `cdk/` change:
7. ✅ iac-security-scan
8. ✅ kiro-iac-security

### Triggered by `pyproject.toml` change:
9. ✅ kiro-dependency-risk
10. ✅ sbom-license

### Changes Made:
- `packages/shared/demo_security.py` — new secure input validation utility
- `infra/cdk/shared_stack.py` — added DevSecOps comment
- `pyproject.toml` — version bump 2.0.0 → 2.1.0

Go to **Actions** tab to see all workflows running in parallel.