### PR TITLE
docs: add disclaimer section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,12 @@ All code passes security scanning with zero findings:
 
 All workflows enforce **least-privilege** (`permissions: contents: read`), **pinned tool versions**, and **pip caching** for fast CI.
 
+## Disclaimer
+
+This project is provided for educational and demonstration purposes. It uses simulated data and is NOT intended for production trading, medical, insurance, or other critical decision-making without proper validation, testing, and regulatory compliance review.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND. See the [LICENSE](LICENSE) file for full terms. The authors assume no liability for any use of this software.
+
 ## License
 
 Apache License 2.0 - see [LICENSE](LICENSE).


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds a **Disclaimer** section to the README to explicitly communicate:

- This project is for **educational and demonstration purposes**
- It uses **simulated data** and is NOT intended for production decision-making
- The software is provided "AS IS" with **no warranty**
- The authors assume **no liability** for any use

## Why

While the Apache-2.0 LICENSE file already contains warranty disclaimers and liability limitations (Sections 7 & 8), adding a visible disclaimer in the README makes this immediately clear to anyone browsing the repository, reducing the risk of misunderstanding the project's intended use.

## Changes

- Added `## Disclaimer` section immediately before `## License` in README.md